### PR TITLE
Fix _limit query parameter

### DIFF
--- a/api.js
+++ b/api.js
@@ -11,7 +11,7 @@ export const api = {
   },
 
   fetchDonations: async () => {
-    const res = await instance.get("/api/donation/donation?_limit='20'")
+    const res = await instance.get("/api/donation/donation?_limit=20")
     return res
   },
 
@@ -26,7 +26,7 @@ export const api = {
   },
 
   fetchSignatures: async () => {
-    const res = await instance.get("/api/signature/signature?_limit='20'")
+    const res = await instance.get("/api/signature/signature?_limit=20")
     return res
   },
 


### PR DESCRIPTION
## Summary
- fetch donations with numeric limit instead of quoted value
- fetch signatures with numeric limit instead of quoted value

## Testing
- `yarn build` *(fails: package not in lockfile)*