### PR TITLE
Add test for donation total endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
   "devDependencies": {
     "autoprefixer": "^10.2.5",
     "postcss": "^8.2.15",
-    "tailwindcss": "^2.1.2"
+    "tailwindcss": "^2.1.2",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   }
 }

--- a/tests/donationTotal.test.js
+++ b/tests/donationTotal.test.js
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import express from 'express';
+import handler from '../pages/api/donation/total';
+import { ModeloDonation } from '../db/Models/schemaDonation';
+
+jest.mock('../db/Models/schemaDonation', () => ({
+  ModeloDonation: { find: jest.fn() }
+}));
+
+const app = express();
+app.get('/api/donation/total', (req, res) => handler(req, res));
+
+describe('GET /api/donation/total', () => {
+  it('returns sum of donation amounts', async () => {
+    ModeloDonation.find.mockResolvedValue([
+      { amount: 10 },
+      { amount: 20 },
+      { amount: 5 }
+    ]);
+
+    const res = await request(app).get('/api/donation/total');
+    expect(res.status).toBe(200);
+    expect(res.body.totalDonado).toBe(35);
+  });
+});


### PR DESCRIPTION
## Summary
- add jest and supertest dev dependencies
- add `test` script
- create a test for `GET /api/donation/total` with mocked donations

## Testing
- `npm test` *(fails: jest not found)*